### PR TITLE
ubports: disable time_daemon

### DIFF
--- a/rootdir/etc/init.disabled.rc
+++ b/rootdir/etc/init.disabled.rc
@@ -22,3 +22,8 @@ service vendor.audio-hal-2-0 android.hardware.audio@2.0-service_HYBRIS_DISABLED
     disabled
     oneshot
     override
+
+service time_daemon time_daemon_HYBRIS_DISABLED
+    disabled
+    oneshot
+    override


### PR DESCRIPTION
This service interferes with the system time set in the host OS.

Tested on the Xiaomi violet.