### PR TITLE
ubports: add a mount point for init configuration files

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -24,6 +24,7 @@ PRODUCT_USE_DYNAMIC_PARTITION_SIZE := true
 PRODUCT_PACKAGES += \
     init.disabled.rc \
     init.halium.rc \
+    init.halium_device.rc \
     vndk-detect \
     on-post-data.sh
 

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -13,6 +13,14 @@ LOCAL_MODULE_PATH  := $(TARGET_OUT_ETC)/init
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE       := init.halium_device.rc
+LOCAL_MODULE_TAGS  := optional eng
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES    := etc/init.halium_device.rc
+LOCAL_MODULE_PATH  := $(TARGET_OUT_ETC)/init
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE       := init.disabled.rc
 LOCAL_MODULE_TAGS  := optional eng
 LOCAL_MODULE_CLASS := ETC

--- a/rootdir/etc/init.halium_device.rc
+++ b/rootdir/etc/init.halium_device.rc
@@ -1,0 +1,3 @@
+# This is an empty configuration file, which is provided as a mount point
+# so that device trees can use it to bind-mount their device-specific init
+# overrides.


### PR DESCRIPTION
This file is emant to be used as a mount point to inject device-specific
changes into the Android init system.