### PR TITLE
ubports: restore Android hal service

### DIFF
--- a/rootdir/etc/init.disabled.rc
+++ b/rootdir/etc/init.disabled.rc
@@ -17,8 +17,3 @@ service vendor.ims_rtp_daemon ims_rtp_daemon_HYBRIS_DISABLED
     disabled
     oneshot
     override
-
-service vendor.audio-hal-2-0 android.hardware.audio@2.0-service_HYBRIS_DISABLED
-    disabled
-    oneshot
-    override


### PR DESCRIPTION
It's not clear why this was disabled; it's an essential service to get
audio working on the Xiaomi Redmi Note 7 Pro (violet).
If it's causing trouble for some devices, an override should be
introduced in these devices' trees, not in this generic image.

Partially reverts aa7f4d5850b8a73a660a4f2a2515d7229465ae49