### PR TITLE
[halium-11.0] halium: disable the new audio hal service

### DIFF
--- a/rootdir/etc/init.disabled.rc
+++ b/rootdir/etc/init.disabled.rc
@@ -22,3 +22,8 @@ service vendor.audio-hal-2-0 android.hardware.audio@2.0-service_HYBRIS_DISABLED
     disabled
     oneshot
     override
+
+service vendor.audio-hal android.hardware.audio.service_DISABLED
+    disabled
+    oneshot
+    override


### PR DESCRIPTION
Android 11 renamed the service to vendor.audio-hal, dropping the version [0].

[0] https://android.googlesource.com/platform/hardware/interfaces/+/de7d06babb5e1dd29390d4f0c63714794bdb697f

Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>