### PR TITLE
(Halium 10) Fixup charger path

### DIFF
--- a/rootdir/etc/init.halium.rc
+++ b/rootdir/etc/init.halium.rc
@@ -44,7 +44,7 @@ on property:sys.boot_completed=1
 on charger
     start charger
 
-service charger /sbin/charger
+service charger /system/bin/charger
     class charger
     group system graphics wakelock
     capabilities BLOCK_SUSPEND SYS_ADMIN SYS_BOOT


### PR DESCRIPTION
As per findings on https://gitlab.com/ubports/porting/reference-device-ports/android10/volla-phone-x/volla-yggdrasilx/-/issues/4#note_1774742314 this appears to also be required for Halium 10.

@amartinz Seems this was possibly missed in testing #9?

This should be definitely tested first (also on more than Volla Phone X?) as I don't have a Halium 10 device handy at the moment.