### PR TITLE
BoardConfig.mk: remove BOARD_CHARGER_DISABLE_INIT_BLANK

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -25,7 +25,6 @@ BOARD_ROOT_EXTRA_FOLDERS += efs
 
 # Offline charging
 BOARD_CHARGER_ENABLE_SUSPEND := true
-BOARD_CHARGER_DISABLE_INIT_BLANK := true
 BOARD_HEALTHD_CUSTOM_CHARGER_RES := $(DEVICE_PATH)/charger/images
 
 # Soong namespaces


### PR DESCRIPTION
the following config causes flicker in offline charging mode on VPX23 - needs to be replaced by 'ro.charger.disable_init_blank=true' property for device who needs the config enabled