### PR TITLE
logd.halium.rc: restore logcat 

### DIFF
--- a/rootdir/etc/init/logd.halium.rc
+++ b/rootdir/etc/init/logd.halium.rc
@@ -8,7 +8,5 @@ service logd /system/bin/logd
 #    file /dev/kmsg w
     user logd
     group logd system package_info readproc
-    capabilities SYSLOG AUDIT_CONTROL
-    priority 10
-    task_profiles ServiceCapacityLow
-    onrestart setprop logd.ready false
+    capabilities SYSLOG AUDIT_CONTROL SETGID
+    writepid /dev/cpuset/system-background/tasks


### PR DESCRIPTION
### Issue 
Since PR #30 logcat does not work anymore on surya / karna and miatoll devices and maybe on all **halium 10** devices:
```sh
phablet@ubuntu-phablet:~$ LD_PRELOAD="" /system/bin/logcat
logcat read failure
```

See issue  #32 

The error is related to logd.halium.rc file :
```sh
phablet@ubuntu-phablet:~$ dmesg |grep -i logd.halium
[   10.256647] init: Parsing file /system/etc/init/logd.halium.rc...
[   10.256802] init: /system/etc/init/logd.halium.rc: 13: Invalid keyword 'task_profiles'
```

### Proposed fix
update `/system/etc/init/logc.halium.rc` file based on `/system/etc/init/logd.rc` file of halium 10
@Azkali
